### PR TITLE
Multinet: improve link auto‑recovery (TCP keepalive, SO_ERROR check, backoff reset)

### DIFF
--- a/pydecnet/decnet/host.py
+++ b/pydecnet/decnet/host.py
@@ -6,6 +6,7 @@
 
 import time
 import socket
+import struct
 import queue
 import os
 import re
@@ -354,6 +355,12 @@ class HostAddress (object):
         assert self.can_connect
         logging.trace ("Connecting from {} to {}", source, self)
         sock = source.bind_socket (self.conn_family)
+        # Best-effort: enable TCP keepalive to detect half-open links
+        try:
+            set_tcp_keepalive (sock)
+        except Exception:
+            # Keepalive tuning is best-effort; ignore if not supported
+            logging.trace ("Keepalive setup failed", exc_info = True)
         sock.setblocking (False)
         try:
             sock.connect (self.sockaddr)
@@ -465,6 +472,41 @@ class SourceAddress (HostAddress):
         except socket.error:
             sock.close()
             raise
+
+def set_tcp_keepalive (sock, idle = 60, interval = 10, count = 5):
+    """Enable TCP keepalive on a socket with reasonable defaults.
+
+    Applies platform-specific tuning when available; silently ignores
+    unsupported options. Times are in seconds.
+    """
+    try:
+        sock.setsockopt (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except Exception:
+        return
+    # Linux-style knobs
+    try:
+        if hasattr (socket, 'TCP_KEEPIDLE'):
+            sock.setsockopt (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, idle)
+        if hasattr (socket, 'TCP_KEEPINTVL'):
+            sock.setsockopt (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval)
+        if hasattr (socket, 'TCP_KEEPCNT'):
+            sock.setsockopt (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, count)
+    except Exception:
+        pass
+    # macOS/BSD: TCP_KEEPALIVE is the idle time (seconds)
+    try:
+        if hasattr (socket, 'TCP_KEEPALIVE'):
+            sock.setsockopt (socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, idle)
+    except Exception:
+        pass
+    # Windows: use SIO_KEEPALIVE_VALS (milliseconds)
+    try:
+        if hasattr (socket, 'SIO_KEEPALIVE_VALS'):
+            # onoff, keepalivetime, keepaliveinterval
+            vals = struct.pack ('III', 1, int (idle * 1000), int (interval * 1000))
+            sock.ioctl (socket.SIO_KEEPALIVE_VALS, vals)
+    except Exception:
+        pass
         
 class NameResolver:
     # Helper class (singleton) to run name lookups in another thread

--- a/pydecnet/decnet/multinet.py
+++ b/pydecnet/decnet/multinet.py
@@ -18,6 +18,7 @@ from .common import *
 from . import datalink
 from . import logging
 from . import host
+import errno
 
 class MultinetUdpPort (datalink.PtpPort):
     """Multinet is exactly like generic point to point except that the
@@ -180,7 +181,7 @@ class _ConnectMultinet (_TcpMultinet):
                 self.socket.close ()
             self.socket = None
         # Next time we'll try the next address, if we have several.
-        x=next (self.dest)
+        x = next (self.dest)
         logging.trace ("Next address is {}", x)
         # Wait a random time, initially in the 5 second range but
         # slowing down as we do more retries, for the outbound
@@ -210,7 +211,20 @@ class _ConnectMultinet (_TcpMultinet):
             if mask & datalink.POLLERRHUP:
                 return False
             if mask & select.POLLOUT:
+                # Confirm non-blocking connect result via SO_ERROR
+                try:
+                    err = sock.getsockopt (socket.SOL_SOCKET, socket.SO_ERROR)
+                except OSError:
+                    err = 0
+                if err:
+                    logging.trace ("Multinet {} connect failed, SO_ERROR {}", self.name, err)
+                    return False
                 logging.trace ("Multinet {} connected", self.name)
+                # Success: collapse connection backoff for faster future retries
+                try:
+                    self.conntmr.reset ()
+                except Exception:
+                    pass
                 return True
 
 class _ListenMultinet (_TcpMultinet):
@@ -227,6 +241,11 @@ class _ListenMultinet (_TcpMultinet):
             self.socket = self.source.create_server ()
             logging.trace ("Multinet {} bind {} done",
                            self.name, self.source)
+            # Successful bind: reset backoff for subsequent failures
+            try:
+                self.conntmr.reset ()
+            except Exception:
+                pass
         except (AttributeError, OSError, socket.error):
             logging.trace ("Multinet {} bind {} failed",
                            self.name, self.source)
@@ -261,6 +280,11 @@ class _ListenMultinet (_TcpMultinet):
                 sock, ainfo = sock.accept ()
                 if self.dest.valid (ainfo):
                     # Good connection, stop looking
+                    # Enable keepalive on accepted sockets to detect half-open peers
+                    try:
+                        host.set_tcp_keepalive (sock)
+                    except Exception:
+                        pass
                     break
                 # If the connect is from someplace we don't want
                 logging.trace ("Multinet {} connect received from " \
@@ -377,7 +401,7 @@ class Multinet (datalink.Datalink):
             m = dev_re.match (config.device)
             if not m:
                 logging.error ("Invalid device value for Multinet datalink {}",
-                               self.name)
+                               name)
                 raise ValueError
             config.destination, port, cmode, lmode, lport = m.groups ()
             config.mode = lmode or cmode


### PR DESCRIPTION
### Summary

Add TCP keepalive on outbound and accepted sockets (Windows/Linux/macOS) to detect half‑open peers and trigger reconnect.
Verify non‑blocking TCP connect success using SO_ERROR after POLLOUT to avoid false positives that stall.
Reset connection backoff on successful connect/bind to avoid long post‑outage delays.
**Minor**: fix factory error logging to use name before instance exists.
Rationale In field use, when a tunnel path or peer dies, links sometimes don’t recover until router restart. OS keepalives and robust connect result checks ensure dead connections are detected; the existing state machine’s reconnect path is then exercised. Resetting backoff on success avoids prolonged recovery delays after a return to health.

### Implementation notes

**decnet/host.py:** add set_tcp_keepalive with platform‑specific tuning; apply in create_connection.
**decnet/multinet.py**: Connect mode: SO_ERROR verification in check_connection; conntmr.reset() on success.
Listen mode: conntmr.reset() after successful bind; enable keepalive on accepted sockets.

### Tests
Light regression via existing Multinet tests (connect/reconnect/accept paths). No public API changes.

Let me know what you think :)